### PR TITLE
Adds recursive search and default author

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ repo_data.json.zip
 .DS_Store
 .idea/
 repo_data.json
+.pyenv/
+*.json.zip

--- a/Makefile
+++ b/Makefile
@@ -1,55 +1,5 @@
-SHELL = /usr/bin/env bash
-
-YELLOW=\033[0;33m
-RED=\033[0;31m
-WHITE=\033[0m
-GREEN=\u001B[32m
-CYAN=
-
-PYTHON3_EXECUTABLE := $(shell command -v python3 2> /dev/null)
-PIP3_EXECUTABLE := $(shell command -v pip3 2> /dev/null)
-
 .PHONY: test
 test:
 	nose2
 docker:
 	docker build -t codersrank/repo_info_extractor:latest .
-
-
-install_pip:
-	@if [ "$(PYTHON3_EXECUTABLE)" != "" ]; then \
-		echo -e "Found $(GREEN)python3$(WHITE)" ;\
-		sudo apt install -y -q python3-venv ;\
-		wait ;\
-		if [ "$(PIP3_EXECUTABLE)" == "" ]; then \
-			if [ -f "get-pip.py" ]; then \
-			echo -e "Downloading latest $(GREEN)pip$(WHITE)" ;\
-			wget https://bootstrap.pypa.io/get-pip.py ; \
-			fi ;\
-			python3 get-pip.py --user ;\
-			wait ;\
-		fi ;\
-		wait ;\
-		rm -rf ./.pyenv ;\
-		python3 -m venv ./.pyenv ;\
-	else \
-		echo -e "Oops it seems python3 isn't installed" ;\
-		echo -e "Run $(GREEN)sudo apt install python3$(WHITE)" ;\
-		echo -e " AND THEN $(GREEN)make install$(WHITE)" ;\
-		exit 0 ;\
-	fi
-
-install_requirements: 
-	@( \
-       source ./.pyenv/bin/activate; \
-       pip3 install  --upgrade pip ; \
-	   pip3 install -r requirements.txt; \
-	   exit 0 ; \
-	)
-
-help:
-	@./run.sh -h
-
-install: install_pip install_requirements help
-
- 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,55 @@
+SHELL = /usr/bin/env bash
+
+YELLOW=\033[0;33m
+RED=\033[0;31m
+WHITE=\033[0m
+GREEN=\u001B[32m
+CYAN=
+
+PYTHON3_EXECUTABLE := $(shell command -v python3 2> /dev/null)
+PIP3_EXECUTABLE := $(shell command -v pip3 2> /dev/null)
+
 .PHONY: test
 test:
 	nose2
 docker:
 	docker build -t codersrank/repo_info_extractor:latest .
+
+
+install_pip:
+	@if [ "$(PYTHON3_EXECUTABLE)" != "" ]; then \
+		echo -e "Found $(GREEN)python3$(WHITE)" ;\
+		sudo apt install -y -q python3-venv ;\
+		wait ;\
+		if [ "$(PIP3_EXECUTABLE)" == "" ]; then \
+			if [ -f "get-pip.py" ]; then \
+			echo -e "Downloading latest $(GREEN)pip$(WHITE)" ;\
+			wget https://bootstrap.pypa.io/get-pip.py ; \
+			fi ;\
+			python3 get-pip.py --user ;\
+			wait ;\
+		fi ;\
+		wait ;\
+		rm -rf ./.pyenv ;\
+		python3 -m venv ./.pyenv ;\
+	else \
+		echo -e "Oops it seems python3 isn't installed" ;\
+		echo -e "Run $(GREEN)sudo apt install python3$(WHITE)" ;\
+		echo -e " AND THEN $(GREEN)make install$(WHITE)" ;\
+		exit 0 ;\
+	fi
+
+install_requirements: 
+	@( \
+       source ./.pyenv/bin/activate; \
+       pip3 install  --upgrade pip ; \
+	   pip3 install -r requirements.txt; \
+	   exit 0 ; \
+	)
+
+help:
+	@./run.sh -h
+
+install: install_pip install_requirements help
+
+ 

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,127 @@
 #!/usr/bin/env bash
+RED=`tput setaf 1`
+GREEN=`tput setaf 2`
+YELLOW=`tput setaf 3`
+BLUE=`tput setaf 4`
+PURPLE=`tput setaf 5`
+CYAN=`tput setaf 6`
+BRIGHT=`tput setaf 7`
 
-python src/main.py "$@"
+BRED=`tput bold && tput setaf 1`
+BGREEN=`tput bold && tput setaf 2`
+BYELLOW=`tput bold && tput setaf 3`
+BBLUE=`tput bold && tput setaf 4`
+BPURPLE=`tput bold && tput setaf 5`
+BCYAN=`tput bold && tput setaf 6`
+BBRIGHT=`tput bold && tput setaf 7`
+
+RESET=`tput sgr0`
+exitfn () {
+    trap SIGINT              
+    echo; echo 'Interrupted by user!!'
+    exit                     
+}
+depth=1
+dry_run=0
+folder="${!#}"
+paramnum=$#
+email=""
+upload='default'
+optspec=":h-:"
+other_args=''
+
+
+trap "exitfn" INT
+
+
+local_projects() {
+  number_of_repos=0
+  concatenated_repos=()
+  for REPO_PATH in `find $folder -maxdepth $depth  -type d  -wholename "*/.git" -exec dirname {} \;`; do
+    concatenated_repos+=("$REPO_PATH")
+    #total_repos=$((total_repos+1))
+    ((number_of_repos+=1))
+    REPO_NAME=`echo $REPO_PATH | sed -e 's/\/$//g' | rev | cut -d'/' -f 1 | rev `  >&2;
+    
+    if [ ! $dry_run -eq 0 ];then 
+      echo "     ${BGREEN}✔️${RESET}  ${BBRIGHT}$REPO_NAME${RESET}"
+    fi
+  done
+    
+  if [ $number_of_repos -eq 0 ]; then
+    echo "${BRED}✖${RESET} We couldn't find any GIT repos under path ${CYAN}$folder${RESET}"
+    echo " "  
+    return
+  fi 
+  echo "Found ${GREEN}$number_of_repos${RESET} repos under ${CYAN}$folder${RESET}"
+  echo " "
+  if [ ! $dry_run -eq 0 ];then 
+      echo " "
+      echo "  You specified the ${BBRIGHT}--dry${RESET} flag."
+      return
+  fi
+  #repostring=`printf "%s➕" "${concatenated_repos[@]}" | sed -e 's/➕$//g' `
+  repostring=`printf "%s|,|" "${concatenated_repos[@]}" | sed -e 's/|,|$//g' `
+
+  bash -c "source ./.pyenv/bin/activate; python src/main.py $other_args \"$repostring\" " ;\
+  wait ;\
+  return
+ 
+}
+
+while getopts "$optspec" optchar; do
+     case "${optchar}" in
+        -)
+            case "${OPTARG}" in
+                dry)
+                    dry_run=1
+                    ;;
+                depth=*)
+                    val=${OPTARG#*=}
+                    opt=${OPTARG%=$val}
+                    depth=$val
+                    ;;
+                *)
+                    other_args="$other_args --$OPTARG"
+                    ;;
+            esac;;
+        h)
+            echo -e ""
+            echo -e "collect your repos info using: "
+            echo -e ""
+            echo -e " ${GREEN}./run.sh${RESET} [${BBRIGHT}--dry${RESET}] [${BBRIGHT}--depth=2${RESET}] [${BBRIGHT}--email=user@domain.com${RESET}] [${BBRIGHT}--skip_upload${RESET}] ${RESET} ${BCYAN}<folder>${RESET} "
+            echo -e ""
+            echo -e "Examples:"
+            echo -e "${GREEN}./run.sh help${RESET}                               display this help message";echo
+            echo -e "${GREEN}./run.sh${RESET} ${BCYAN}~/my_repo${RESET}                   parse info of ${BCYAN}my_repo${RESET}"
+            echo -e "${GREEN}./run.sh${RESET} ${BBRIGHT}--dry${RESET}  ${BCYAN}~/my_repo${RESET}            just display repos that would be examined"
+            echo -e "${GREEN}./run.sh${RESET} ${BBRIGHT}--skip_upload${RESET}  ${BCYAN}~/my_repo${RESET}    skip auto upload prompt"
+            echo -e "${GREEN}./run.sh${RESET} --email=${BBRIGHT}me@mail.com${RESET} ${BCYAN}~/repo${RESET}  preselect ${BCYAN}me@mail.com${RESET} in author list"
+            
+            echo; echo -e "${GREEN}./run.sh${RESET} ${BBRIGHT}--depth=2${RESET}  ${BCYAN}~/projects${RESET}        sarch recursively N levels from ${BCYAN}~/projects${RESET}"
+            echo -e "               (this option replaces the ${BRIGHT}--output${RESET} parameter with folder names)"
+            echo -e ""
+            echo -e "Combine them all (options available in ${GREEN}main.py${RESET} will be forwared untouched)";echo
+            echo -e "${GREEN}./run.sh ${RESET} --depth=2 --parse_libraries --email=me@mail.com --skip_upload  ${BCYAN}~/projects${RESET}"
+
+            echo ""
+            exit 0
+            ;;
+       
+            
+      
+        *)
+            if [ "$OPTERR" != 1 ] || [ "${optspec:0:1}" = ":" ]; then
+                echo "Non-option argument: '-${OPTARG}'" >&2
+            fi
+            ;;
+    esac
+done 
+
+  echo "Search repos on ${BPURPLE}$folder${RESET}, ${BCYAN}$depth${RESET} folders deep "
+  #$other_args"
+  local_projects
+  echo "Finished"
+  echo " "
+trap SIGINT
+exit 0

--- a/run.sh
+++ b/run.sh
@@ -63,7 +63,7 @@ local_projects() {
   #repostring=`printf "%s➕" "${concatenated_repos[@]}" | sed -e 's/➕$//g' `
   repostring=`printf "%s|,|" "${concatenated_repos[@]}" | sed -e 's/|,|$//g' `
 
-  bash -c "source ./.pyenv/bin/activate; python src/main.py $other_args \"$repostring\" " ;\
+  python src/main.py $other_args "$repostring" ;\
   wait ;\
   return
  

--- a/src/export_result.py
+++ b/src/export_result.py
@@ -10,12 +10,14 @@ class ExportResult:
     def __init__(self, data):
         self.data = data
 
-    def export_to_json_interactive(self, file_name):
+    def export_to_json_interactive(self, file_name, skip_upload=False):
         self.dump(file_name)
 
         q = Questions()
-
-        result = q.query_yes_no(
+        if skip_upload != False:
+            result = False
+        else:
+            result = q.query_yes_no(
             'Do you want to upload the result to your profile automatically?')
         if result:
             response = uploadRepo(file_name + '.zip')

--- a/src/init.py
+++ b/src/init.py
@@ -8,29 +8,49 @@ from ui.questions import Questions
 from obfuscator import obfuscate
 
 
-def initialize(directory, skip_obfuscation, output, parse_libraries):
+def initialize(directory, skip_obfuscation, output, parse_libraries, email, skip_upload):
     repo = git.Repo(directory)
     ar = AnalyzeRepo(repo)
     q = Questions()
 
-    print('Initialization...')
-    for branch in repo.branches:
-        ar.create_commits_entity_from_branch(branch.name)
-    ar.flag_duplicated_commits()
-    ar.get_commit_stats()
-    r = ar.create_repo_entity(directory)
+    print('Analyzing repo under %s ...' % (directory))
 
-    # Ask the user if we cannot find remote URL
-    if r.primary_remote_url == '':
-        answer = q.ask_primary_remote_url(r)
-
-    authors = [(c['name'], c['email']) for _, c in r.contributors.items()]
-    identities = {}
-    identities['user_identity'] = []
-    # In case the repo is empty don't show the question
-    if len(authors) != 0:
+    try:
+        # Stop parsing if there are no branches
+        if not repo.branches:
+            print('No branches detected, will ignore this repo')
+            return
+    
+        for branch in repo.branches:
+            ar.create_commits_entity_from_branch(branch.name)
+        ar.flag_duplicated_commits()
+        ar.get_commit_stats()
+        r = ar.create_repo_entity(directory)
+    
+        # Stop parsing if there are no remotes
+        if not r.original_remotes:
+            print('No remotes detected, will ignore this repo')
+            return
+    
+        # Ask the user if we cannot find remote URL
+        if r.primary_remote_url == '':
+            answer = q.ask_primary_remote_url(r)
+    
+        if not r.contributors.items():
+            print('No authors detected, will ignore this repo')
+            return
+    
+        authors = [(c['name'], c['email']) for _, c in r.contributors.items()]
+        identities = {}
+        identities['user_identity'] = []
+    
+        # Stop parsing if there are no authors
+        if len(authors) == 0:
+            print('No authors detected, will ignore this repo')
+            return
+    
         identities_err = None
-        identities = q.ask_user_identity(authors, identities_err)
+        identities = q.ask_user_identity(authors, identities_err, email)
         MAX_LIMIT = 50
         while len(identities['user_identity']) == 0 or len(identities['user_identity']) > MAX_LIMIT:
             if len(identities['user_identity']) == 0:
@@ -38,25 +58,27 @@ def initialize(directory, skip_obfuscation, output, parse_libraries):
             if len(identities['user_identity']) > MAX_LIMIT:
                 identities_err = 'You cannot select more than', MAX_LIMIT
             identities = q.ask_user_identity(authors, identities_err)
-
-    r.local_usernames = identities['user_identity']
-
-    if parse_libraries:
-        # build authors from the selection
-        al = AnalyzeLibraries(r.commits, authors, repo.working_tree_dir)
-        libs = al.get_libraries()
-
-        # combine repo stats with libs used
-        for i in range(len(r.commits)):
-            c = r.commits[i]
-            if c.hash in libs.keys():
-                r.commits[i].libraries = libs[c.hash]
-
-    if not skip_obfuscation:
-        r = obfuscate(r)
-
-    er = ExportResult(r)
-    er.export_to_json_interactive(output)
+        r.local_usernames = identities['user_identity']
+        
+        if parse_libraries:
+            # build authors from the selection
+            al = AnalyzeLibraries(r.commits, authors, repo.working_tree_dir)
+            libs = al.get_libraries()
+            # combine repo stats with libs used
+            for i in range(len(r.commits)):
+                c = r.commits[i]
+                if c.hash in libs.keys():
+                    r.commits[i].libraries = libs[c.hash]
+        
+        if not skip_obfuscation:
+            r = obfuscate(r)
+        er = ExportResult(r)
+        er.export_to_json_interactive(output, skip_upload)
+    except KeyboardInterrupt:
+        print ("Cancelled by user")
+        return
+    except Exception:
+        return
 
 # user_commit - consider only these user commits for extracting the repo information
 # emails - merge these emails with these emails extracted from the repo

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,9 @@
 import argparse
 from init import initialize
+from pprint import pprint
+import os
+from ui.questions import Questions
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -7,14 +11,36 @@ def main():
         'directory', help='Path to the repository. Example usage: run.sh path/to/directory')
     parser.add_argument('--output', default='./repo_data.json', dest='output',
                         help='Path to the JSON file that will contain the result')
-    parser.add_argument('--skip_obfuscation', default=False, dest='skip_obfuscation',
+    parser.add_argument('--skip_obfuscation', default=False, dest='skip_obfuscation', action='store_true',
                         help='If true it won\'t obfuscate the sensitive data such as emails and file names. Mostly for testing purpuse')
-    parser.add_argument('--parse_libraries', default=False,
+    parser.add_argument('--parse_libraries',  default=False, action='store_true',
                         dest='parse_libraries', help='If true, used libraries will be parsed')
+    parser.add_argument('--email', default='',
+                        dest='email', help='If set, commits from this email are preselected on authors list')
+    parser.add_argument('--skip_upload',  default=False, action='store_true',
+                        dest='skip_upload', help="If true, don't prompt for inmediate upload")
+    try:
+        args = parser.parse_args()
+        folders=args.directory.split('|,|')
+        if len(folders) > 1:
+            q = Questions()
+            repos = q.ask_which_repos(folders)
+            if 'chosen_repos' not in repos or len(repos['chosen_repos']) == 0:
+                print("No repos chosen, will exit")
+            for repo in repos['chosen_repos']:
+                repo_name = os.path.basename(repo).replace(' ','_')
+                output=('./%s.json' % (repo_name))
+                initialize(repo, args.skip_obfuscation, output, args.parse_libraries, args.email, args.skip_upload)
+                print('Finished analyzing %s ' % (repo_name))
 
-    args = parser.parse_args()
-    initialize(args.directory, args.skip_obfuscation, args.output, args.parse_libraries)
+        else:
+            initialize(args.directory, args.skip_obfuscation, args.output, args.parse_libraries, args.email, args.skip_upload)
 
+    except KeyboardInterrupt:
+        print ("Cancelled by user")
+        os._exit(0)
+    except Exception:
+        os._exit(0)
 
 if __name__ == "__main__":
     import multiprocessing

--- a/src/ui/questions.py
+++ b/src/ui/questions.py
@@ -22,15 +22,17 @@ class Questions:
 
         return prompt(questions)
 
-    def ask_user_identity(self, authors, err):
+    def ask_user_identity(self, authors, err, email=''):
         choices = []
         for name, email in authors:
+            checked = email == email
             choices.append({
                 'name': name + ' -> ' + email,
+                'checked': checked
             })
-
-        message = 'The following contributors were found in the repository. \
-            Select which ones you are. (With SPACE you can select more than one)'
+            
+        message = """The following contributors were found in the repository. 
+                     Select which ones you are. (With SPACE you can select more than one)"""
         if err:
             message = "%s [ERROR] %s" % (message, err)
 
@@ -38,6 +40,29 @@ class Questions:
             {
                 'type': 'checkbox',
                 'name': 'user_identity',
+                'message': message,
+                'choices': choices
+            }
+        ]
+
+        return prompt(questions)
+
+    def ask_which_repos(self, repos):
+        choices = []
+        for repo in repos:
+            choices.append({
+                'name': repo
+            })
+            
+        message = """\
+The following repos where found in the given path. 
+Select which ones you want to analyze (With SPACE you can select more than one)
+"""
+        
+        questions = [
+            {
+                'type': 'checkbox',
+                'name': 'chosen_repos',
                 'message': message,
                 'choices': choices
             }

--- a/src/ui/questions.py
+++ b/src/ui/questions.py
@@ -22,17 +22,17 @@ class Questions:
 
         return prompt(questions)
 
-    def ask_user_identity(self, authors, err, email=''):
+    def ask_user_identity(self, authors, err, default_email=''):
         choices = []
         for name, email in authors:
-            checked = email == email
+            checked = email == default_email
             choices.append({
                 'name': name + ' -> ' + email,
                 'checked': checked
             })
             
-        message = """The following contributors were found in the repository. 
-                     Select which ones you are. (With SPACE you can select more than one)"""
+        message = 'The following contributors were found in the repository. \
+            Select which ones you are. (With SPACE you can select more than one)'
         if err:
             message = "%s [ERROR] %s" % (message, err)
 
@@ -54,16 +54,14 @@ class Questions:
                 'name': repo
             })
             
-        message = """\
-The following repos where found in the given path. 
-Select which ones you want to analyze (With SPACE you can select more than one)
-"""
+        print("We found the following repos in the chosen path")
+
         
         questions = [
             {
                 'type': 'checkbox',
                 'name': 'chosen_repos',
-                'message': message,
+                'message': 'Select which ones you want to analyze (With SPACE you can select more than one)',
                 'choices': choices
             }
         ]


### PR DESCRIPTION

Adds a few enhancements to use the extractor
(assuming there is Python 3.x + bash + Makefile)

-  Point to a folder containing several repos, and pass `depth` parameter to search recursively 

```bash
./run.sh  --depth=2 ~/projects 
```
![recursive_search gif](https://user-images.githubusercontent.com/238439/66866299-610a8b00-ef6f-11e9-96bd-75200f1df00d.gif)

(when using the `depth` option the value of `output` is ignored and replaced with the folder name of each repo. This could be enhanced soon to instead create a folder named after the `output` parameter)

________________
- You can pass default email to preselect matching authors

```bash
./run.sh  --email=amenadiel@mail.com ~/projects/repo
```

![preselect_emails2](https://user-images.githubusercontent.com/238439/66866430-a7f88080-ef6f-11e9-9647-1213a01bd8ed.gif)

________________
- Can skip auto upload prompt (if extracting several repos, you know...)

```bash
./run.sh  --upload=skip ~/projects/repo
```
![skip_upload](https://user-images.githubusercontent.com/238439/66866500-cf4f4d80-ef6f-11e9-8257-70d0b6d8d790.gif)


________________________
 - Exception handling and exit early on edge cases
   - no branches
   - no commits
   - no authors
   - keyboard interrupt

_______________



The following changes were reverted and will be reconsidered, perhaps as an optional approach.


~~Everything runs on a virtualenv~~
~~make install installs python-venv and creates virtualenv (given you have python3) to avoid issues with versions and permissions~~
~~./run.sh activates the virtualenv when invoking src/main.py~~


