### PR TITLE
Fix headless mode and user selection

### DIFF
--- a/src/analyze_libraries.py
+++ b/src/analyze_libraries.py
@@ -13,15 +13,19 @@ from datetime import datetime
 
 
 class AnalyzeLibraries:
-    def __init__(self, commit_list, authors, basedir):
+    def __init__(self, commit_list, author_emails, basedir):
         self.commit_list = commit_list
-        self.authors = authors
+        self.author_emails = author_emails
         self.basedir = basedir
 
     # Return a dict of commit -> language -> list of libraries
     def get_libraries(self):
         res = {}
-        commits = _filter_commits_by_authors(self.commit_list, self.authors)
+        commits = _filter_commits_by_author_emails(self.commit_list, self.author_emails)
+        if not commits:
+            print("[%s] No commmits found for the authored by selected users" % datetime.now().strftime("%d/%m/%Y %H:%M:%S"))	
+            return res
+
         # Before we do anything, copy the repo to a temporary location so that we don't mess with the original repo
         tmp_repo_path = _get_temp_repo_path()
         
@@ -66,6 +70,7 @@ class AnalyzeLibraries:
 
             prog += 1
             progress(prog, total, 'Analyzing libraries')
+
             if libs_in_commit:
                 res[commit.hash] = libs_in_commit
 
@@ -74,8 +79,9 @@ class AnalyzeLibraries:
 
 
 # Return only commits authored by provided obfuscated_author_emails
-def _filter_commits_by_authors(commit_list, authors):
-    return list(filter(lambda x: (x.author_name, x.author_email) in authors, commit_list))
+def _filter_commits_by_author_emails(commit_list, author_emails):
+    print("[%s] Filtering commits by emails ." % datetime.now().strftime("%d/%m/%Y %H:%M:%S"), author_emails)	
+    return list(filter(lambda x:  x.author_email in author_emails, commit_list))
 
 
 def _get_temp_repo_path():

--- a/src/init.py
+++ b/src/init.py
@@ -62,14 +62,18 @@ def initialize(directory, skip_obfuscation, output, parse_libraries, email, skip
         
         if parse_libraries:
             # build authors from the selection
-            al = AnalyzeLibraries(r.commits, authors, repo.working_tree_dir)
-            libs = al.get_libraries()
-            # combine repo stats with libs used
-            for i in range(len(r.commits)):
-                c = r.commits[i]
-                if c.hash in libs.keys():
-                    r.commits[i].libraries = libs[c.hash]
-        
+            # extract email from name -> email list
+            author_emails = [i.split(' -> ', 1)[1] for i in r.local_usernames]
+
+            if author_emails:
+                al = AnalyzeLibraries(r.commits, author_emails, repo.working_tree_dir)
+                libs = al.get_libraries()
+                # combine repo stats with libs used
+                for i in range(len(r.commits)):
+                    c = r.commits[i]
+                    if c.hash in libs.keys():
+                        r.commits[i].libraries = libs[c.hash]
+            
         if not skip_obfuscation:
             r = obfuscate(r)
         er = ExportResult(r)
@@ -103,15 +107,20 @@ def init_headless(directory, skip_obfuscation, output, parse_libraries, emails, 
     r.repo_name = reponame
 
     if parse_libraries:
-        # build authors from the selection
-        al = AnalyzeLibraries(r.commits, authors, repo.working_tree_dir)
-        libs = al.get_libraries()
+        # build authors from the the email list provided 
+        author_emails = []
+        for email in r.local_usernames:
+            author_emails.append(email)
+        
+        if author_emails:
+            al = AnalyzeLibraries(r.commits, author_emails, repo.working_tree_dir)
+            libs = al.get_libraries()
 
-        # combine repo stats with libs used
-        for i in range(len(r.commits)):
-            c = r.commits[i]
-            if c.hash in libs.keys():
-                r.commits[i].libraries = libs[c.hash]
+            # combine repo stats with libs used
+            for i in range(len(r.commits)):
+                c = r.commits[i]
+                if c.hash in libs.keys():
+                    r.commits[i].libraries = libs[c.hash]
 
     if not skip_obfuscation:
         r = obfuscate(r)

--- a/src/init.py
+++ b/src/init.py
@@ -108,6 +108,8 @@ def init_headless(directory, skip_obfuscation, output, parse_libraries, emails, 
 
     if parse_libraries:
         # build authors from the the email list provided 
+        # we are provided only emails in the headless mode
+        # TODO! Support both name -> email and email formats
         author_emails = []
         for email in r.local_usernames:
             author_emails.append(email)

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,7 @@ def main():
                         help='Path to the JSON file that will contain the result')
     parser.add_argument('--skip_obfuscation', default=False, dest='skip_obfuscation', action='store_true',
                         help='If true it won\'t obfuscate the sensitive data such as emails and file names. Mostly for testing purpuse')
-    parser.add_argument('--parse_libraries',  default=False, action='store_true',
+    parser.add_argument('--parse_libraries',  default=True, action='store_true',
                         dest='parse_libraries', help='If true, used libraries will be parsed')
     parser.add_argument('--email', default='',
                         dest='email', help='If set, commits from this email are preselected on authors list')


### PR DESCRIPTION
this fixes the following

- Even though particular committers were selected, libraries were extracted for everyone
- Headless mode was just plain broken since authors were not defined


Also, importantly, it makes ***extracting libraries to be enabled by default***