### PR TITLE
Feature/refactor repo search

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -60,10 +60,7 @@ local_projects() {
       echo "  You specified the ${BBRIGHT}--dry${RESET} flag."
       return
   fi
-  #repostring=`printf "%s➕" "${concatenated_repos[@]}" | sed -e 's/➕$//g' `
-  repostring=`printf "%s|,|" "${concatenated_repos[@]}" | sed -e 's/|,|$//g' `
-
-  python src/main.py $other_args "$repostring" ;\
+  python src/main.py $other_args --depth=$depth "$folder" ;\
   wait ;\
   return
  

--- a/run.sh
+++ b/run.sh
@@ -127,6 +127,12 @@ email=""
 upload='default'
 optspec=":h-:"
 other_args=''
+
+if [ $paramnum -eq 0 ]; then
+  print_help
+  exit 0
+fi
+
 while getopts "$optspec" optchar; do
      case "${optchar}" in
         -)

--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,10 @@ BPURPLE=`tput bold && tput setaf 5`
 BCYAN=`tput bold && tput setaf 6`
 BBRIGHT=`tput bold && tput setaf 7`
 
+
+cr_green=`tput setaf 73`
+cr_blue=`tput setaf 25`
+
 RESET=`tput sgr0`
 exitfn () {
     trap SIGINT              
@@ -24,6 +28,33 @@ exitfn () {
 
 trap "exitfn" INT
 
+print_logo() {
+  echo
+  echo -e "${cr_blue}                                          ':'   ${cr_green}                                ${RESET}"
+  echo -e "${cr_blue}                                       .+ymo     ${cr_green}     .+/:.                     ${RESET}"
+  echo -e "${cr_blue}                                    -ohmmms'     ${cr_green}    '++++++/-'                 ${RESET}"
+  echo -e "${cr_blue}                                ':sdmmmmmh'     ${cr_green}    '/+++++++++/-.              ${RESET}"
+  echo -e "${cr_blue}                             '/ymmmmmmmmd.     ${cr_green}     /++++++++++++++:-'          ${RESET}"
+  echo -e "${cr_blue}                          .+hmmmmmmmmmmm-       ${cr_green}   :++++++++++++++++++/-'       ${RESET}"
+  echo -e "${cr_blue}                       -odmmmmmmmmmmmmm/        ${cr_green}   -:+++++++++++++++++++++:.    ${RESET}"
+  echo -e "${cr_blue}                   ':sdmmmmmmmmmmmmmmm+         ${cr_green}      .-/+++++++++++++++++++/'  ${RESET}"
+  echo -e "${cr_blue}                ./ymmmmmmmmmmmmmmmmmmo         ${cr_green}          '-:+++++++++++++++++-  ${RESET}"
+  echo -e "${cr_blue}             -+hmmmmmmmmmmmmmmmmmds/'         ${cr_green}              /++++++++++++++++-  ${RESET}"
+  echo -e "${cr_blue}         ':odmmmmmmmmmmmmmmmmmho-           ${cr_green}            '.:++++++++++++++++++.  ${RESET}"
+  echo -e "${cr_blue}      '/smmmmmmmmmmmmmmmmmmy/.                ${cr_green}       '-/++++++++++++++++++/-'   ${RESET}"
+  echo -e "${cr_blue}    /ymmmmmmmmmmmmmmmmmds:'                ${cr_green}      '.:+++++++++++++++++++:-'      ${RESET}"
+  echo -e "${cr_blue}   ommmmmmmmmmmmmmmmd+-                   ${cr_green}    .-/++++++++++++++++++/:.          ${RESET}"
+  echo -e "${cr_blue}   ymmmmmmmmmmmmmmmm+                    ${cr_green}  .:+++++++++++++++++++/-'             ${RESET}"
+  echo -e "${cr_blue}   ymmmmmmmmmmmmmmmmmds/'              ${cr_green}   :+++++++++++++++++/:.'                ${RESET}"
+  echo -e "${cr_blue}   .hmmmmmmmmmmmmmmmmmmmmho:'         ${cr_green}   -+++++++++++++++++:                    ${RESET}"
+  echo -e "${cr_blue}     .+ymmmmmmmmmmmmmmmmmmmmms       ${cr_green}   -+++++++++++++++++++:'                  ${RESET}"
+  echo -e "${cr_blue}        ':sdmmmmmmmmmmmmmmmmd-      ${cr_green}   .+++++++++++++++++++++/'                 ${RESET}"
+  echo -e "${cr_blue}            .+ymmmmmmmmmmmmm:       ${cr_green}  .++++++++/-/+++++++++++++-                ${RESET}"
+  echo -e "${cr_blue}               ':ohmmmmmmmm/      ${cr_green}   '++++++:.   ':+++++++++++++:'              ${RESET}"
+  echo -e "${cr_blue}                   ./smmmmo      ${cr_green}   '/++/-'        .+++++++++++++/'             ${RESET}"
+  echo -e "${cr_blue}                       -++      ${cr_green}    /:.'            ':++++++++++++/             ${RESET}"
+  echo
+}
 parameter_definition() {
   echo -e " ${BBRIGHT} $1 ${RESET}    $2  $3"
 }
@@ -111,6 +142,10 @@ while getopts "$optspec" optchar; do
 
                 help)
                     print_help
+                    exit 0
+                    ;;
+                logo)
+                    print_logo
                     exit 0
                     ;;
                 *)

--- a/src/init.py
+++ b/src/init.py
@@ -74,6 +74,10 @@ def initialize(directory, skip_obfuscation, output, parse_libraries, email, skip
         identities_err = None
         identities = q.ask_user_identity(authors, identities_err, email)
         MAX_LIMIT = 50
+        # If the user aborts the prompt with CTRL+C, avoid crashing and return instead
+        if 'user_identity' not in identities:
+            print('No authors detected, will ignore this repo')
+            return
         while len(identities['user_identity']) == 0 or len(identities['user_identity']) > MAX_LIMIT:
             if len(identities['user_identity']) == 0:
                 identities_err = 'Please select at least one author'

--- a/src/ui/questions.py
+++ b/src/ui/questions.py
@@ -3,7 +3,7 @@ import sys
 
 def sort_by_checked_and_email(d):
     """ Sort by author match, then email. """
-    email=d['name'].split(' -> ', 1)[1]
+    email=d['name'].split(' -> ', 1)[1].lower()
     checked=d['checked']
     order = '1'+email
     if(checked==True):
@@ -64,7 +64,7 @@ class Questions:
             
         print("We found the following repos in the chosen path")
 
-        sorted_choices = sorted(choices, key= lambda x: x['name'])
+        sorted_choices = sorted(choices, key= lambda x: x['name'].lower())
         questions = [
             {
                 'type': 'checkbox',

--- a/src/ui/questions.py
+++ b/src/ui/questions.py
@@ -1,6 +1,14 @@
 from whaaaaat import style_from_dict, Token, prompt, print_json, default_style, Separator
 import sys
 
+def sort_by_checked_and_email(d):
+    """ Sort by author match, then email. """
+    email=d['name'].split(' -> ', 1)[1]
+    checked=d['checked']
+    order = '1'+email
+    if(checked==True):
+        order = '0'+email
+    return order
 
 class Questions:
 
@@ -30,7 +38,7 @@ class Questions:
                 'name': name + ' -> ' + email,
                 'checked': checked
             })
-            
+        choices.sort(key=sort_by_checked_and_email)
         message = 'The following contributors were found in the repository. \
             Select which ones you are. (With SPACE you can select more than one)'
         if err:
@@ -56,13 +64,13 @@ class Questions:
             
         print("We found the following repos in the chosen path")
 
-        
+        sorted_choices = sorted(choices, key= lambda x: x['name'])
         questions = [
             {
                 'type': 'checkbox',
                 'name': 'chosen_repos',
                 'message': 'Select which ones you want to analyze (With SPACE you can select more than one)',
-                'choices': choices
+                'choices': sorted_choices
             }
         ]
 


### PR DESCRIPTION
### Let python search for nested repos

When running on a folder with several repos, instead of having `run.sh` search for them (cumbersome concatenation)
https://github.com/codersrank-org/repo_info_extractor/blob/bea11386acb70df0cd961e2e2450a88a6f3dc177/run.sh#L41
https://github.com/codersrank-org/repo_info_extractor/blob/bea11386acb70df0cd961e2e2450a88a6f3dc177/run.sh#L64


then exploding in python

https://github.com/codersrank-org/repo_info_extractor/blob/bea11386acb70df0cd961e2e2450a88a6f3dc177/src/main.py#L32

I believe is easier to understand (therefore, mantain) if we let python be in charge of traversing the nested repos:

```python
directory=Path(args.directory)
if(args.depth!=1):
    for folder in directory.glob('*/*.git'):
        folders.append('%s' % (folder.parent))
```
With this modification, there is no need for no concatenation on `run.sh`. 


### When parsing libraries, don't copy the whole folder

Currently, the whole repo folder is copied to a temporary location, including vendor code, generated code and ignored files (which can be huge, e.g. logs).



https://github.com/codersrank-org/repo_info_extractor/blob/bea11386acb70df0cd961e2e2450a88a6f3dc177/src/analyze_libraries.py#L41

Then the temporary copy is cleaned

https://github.com/codersrank-org/repo_info_extractor/blob/bea11386acb70df0cd961e2e2450a88a6f3dc177/src/analyze_libraries.py#L46-L50

It's faster to copy just the `.git` folder. When performing a `git checkout master` on it, the versioned files, and nothing else, will be in the local copy

```python
            shutil.copytree("%s/.git" % (self.basedir),
                            "%s/.git" % ( tmp_repo_path),
                            symlinks=True)
```

### Sort 

 - When displaying the repos found in a folder, sort them alphabetically 

Before:
![image](https://user-images.githubusercontent.com/238439/70697587-8fbd8d00-1ca4-11ea-823e-a2ccd695eae9.png)

After
![image](https://user-images.githubusercontent.com/238439/70697634-a2d05d00-1ca4-11ea-9799-58ba73ae7c36.png)


 - When displaying the contributors, sort them by email. BUT, if you passed in the `--email` arg, the preselected options will appear first.

Before:
![image](https://user-images.githubusercontent.com/238439/70698182-b4fecb00-1ca5-11ea-9a7e-1702b1ffdca3.png)

After:
![image](https://user-images.githubusercontent.com/238439/70698330-0313ce80-1ca6-11ea-8cde-22b0e0c234f2.png)



### Bonus Track

Running `./run.sh --logo` will print:

![image](https://user-images.githubusercontent.com/238439/70697190-d5c62100-1ca3-11ea-90df-83147aa530a3.png)

It might come in handy one day...