### PR TITLE
Detect OpenEdge ABL language

### DIFF
--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -34,6 +34,7 @@ supported_languages = {
     'Lua': ['lua'],
     'MATLAB': ['m'],
     'Objective-C': ['mm'],
+    'OpenEdge ABL': ['p', 'ab', 'w', 'i', 'x', 'cls'],
     'Perl': ['pl'],
     'PHP': ['php'],
     'PLSQL': ['pks', 'pkb'],

--- a/test/test_detect_language.py
+++ b/test/test_detect_language.py
@@ -59,6 +59,11 @@ def test_languages_recognised():
     assert detect_language.detect_language("/tmp/some_file.m") == "MATLAB"
     assert detect_language.detect_language(
         "/tmp/some_file.mm") == "Objective-C"
+    assert detect_language.detect_language("/tmp/some_file.p") == "OpenEdge ABL"
+    assert detect_language.detect_language("/tmp/some_file.w") == "OpenEdge ABL"
+    assert detect_language.detect_language("/tmp/some_file.i") == "OpenEdge ABL"
+    assert detect_language.detect_language("/tmp/some_file.cls") == "OpenEdge ABL"
+    assert detect_language.detect_language("/tmp/some_file.ab") == "OpenEdge ABL"
     assert detect_language.detect_language("/tmp/some_file.pkb") == "PLSQL"
     assert detect_language.detect_language("/tmp/some_file.pks") == "PLSQL"    
     assert detect_language.detect_language("/tmp/some_file.pl") == "Perl"


### PR DESCRIPTION
Add support to detect OpenEdge ABL language.
Does not include support to detect "SpeedScript" (a web-oriented OpenEdge ABL child language)