### PR TITLE
Accept all batch file formats

### DIFF
--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -5,7 +5,7 @@ supported_languages = {
     '1C Enterprise': ['bsl', 'os'],
     'Apex': ['cls'],
     'Assembly': ['asm'],
-    'Batchfile': ['bat'],
+    'Batchfile': ['bat', 'cmd', 'btm'],
     'C': ['c'],
     'C++': ['cpp', 'cxx'],
     'C#': ['cs'],


### PR DESCRIPTION
Currently, `cmd` and `btm` files aren't detected as batch files. This commit solves this.