### PR TITLE
Add support for kivy files

### DIFF
--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -32,6 +32,7 @@ supported_languages = {
     'Java': ['java'],
     'JavaScript': ['js', 'jsx'],
     'Jupyter Notebook': ['ipynb'],
+    'Kivy': ['kv'],
     'Kotlin': ['kt', 'kts'],
     'Less': ['less'], 
     'Liquid': ['liquid'],
@@ -60,7 +61,6 @@ supported_languages = {
     'Vue': ['vue'],
     'Xtend': ['xtend'],
     'Xtext': ['xtext'],
-    'Kivy': ['kv'],
 }
 
 _ext_lang = {}

--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -60,6 +60,7 @@ supported_languages = {
     'Vue': ['vue'],
     'Xtend': ['xtend'],
     'Xtext': ['xtext'],
+    'Kivy': ['kv'],
 }
 
 _ext_lang = {}

--- a/test/test_detect_language.py
+++ b/test/test_detect_language.py
@@ -64,6 +64,7 @@ def test_languages_recognised():
     assert detect_language.detect_language("/tmp/some_file.java") == "Java"
     assert detect_language.detect_language(
         "/tmp/some_file.ipynb") == "Jupyter Notebook"
+    assert detect_language.detect_language("/tmp/some_file.kv") == "Kivy"
     assert detect_language.detect_language("/tmp/some_file.liquid") == "Liquid"
     assert detect_language.detect_language("/tmp/some_file.lua") == "Lua"
     assert detect_language.detect_language(pwd + "/test/fixtures/matlab.m") == "MATLAB"


### PR DESCRIPTION
Kivy is a graphical interface framework for python.
At the moment, only python library imports of kivy are properly detected. 
However, kivy also supports interface description via its own file [format](https://kivy.org/doc/stable/examples/gen__application__app_with_kv__py.html).
These files use the `.kv` suffix.
This would be a preliminary solution. Ideally, library and language could be combined into one metric.