### PR TITLE
Support detecting Perl modules by extension

### DIFF
--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -40,7 +40,7 @@ supported_languages = {
     'Nix': ['nix'],
     'Objective-C': ['mm'],
     'OpenEdge ABL': ['p', 'ab', 'w', 'i', 'x'],
-    'Perl': ['pl'],
+    'Perl': ['pl', 'pm'],
     'PHP': ['php'],
     'PLSQL': ['pks', 'pkb'],
     'Protocol Buffer': ['proto'],

--- a/test/test_detect_language.py
+++ b/test/test_detect_language.py
@@ -80,6 +80,7 @@ def test_languages_recognised():
     assert detect_language.detect_language("/tmp/some_file.pkb") == "PLSQL"
     assert detect_language.detect_language("/tmp/some_file.pks") == "PLSQL"    
     assert detect_language.detect_language("/tmp/some_file.pl") == "Perl"
+    assert detect_language.detect_language("/tmp/some_file.pm") == "Perl"
     assert detect_language.detect_language("/tmp/some_file.php") == "PHP"
     assert detect_language.detect_language(
         "/tmp/some_file.proto") == "Protocol Buffer"


### PR DESCRIPTION
This PR is an attempt to solve #122 by adding initial support for recognizing Perl modules by their common filename extension (`.pm`).

I'm opening it first as a draft PR to allow for early feedback while I get the tests passing.