### PR TITLE
feat: detect xhtml files as HTML

### DIFF
--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -27,7 +27,7 @@ supported_languages = {
     'Go': ['go'],
     'Haskell': ['hs', 'lhs'],
     'HCL': ['hcl', 'tf', 'tfvars'],
-    'HTML': ['html', 'htm'],
+    'HTML': ['html', 'htm', 'xhtml'],
     'JSON': ['json'],
     'Java': ['java'],
     'JavaScript': ['js', 'jsx'],

--- a/test/test_detect_language.py
+++ b/test/test_detect_language.py
@@ -62,6 +62,7 @@ def test_languages_recognised():
     assert detect_language.detect_language("/tmp/some_file.tfvars") == "HCL"
     assert detect_language.detect_language("/tmp/some_file.html") == "HTML"
     assert detect_language.detect_language("/tmp/some_file.htm") == "HTML"
+    assert detect_language.detect_language("/tmp/some_file.xhtml") == "HTML"
     assert detect_language.detect_language("/tmp/some_file.json") == "JSON"
     assert detect_language.detect_language("/tmp/some_file.java") == "Java"
     assert detect_language.detect_language("/tmp/some_file.js") == "JavaScript"


### PR DESCRIPTION
`.xhtml` isn't the standard anymore but Codersrank is supposed to evaluate older projects as well and it might still be used by some templating frameworks.