### PR TITLE
feat: detect toml and yaml

### DIFF
--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -57,10 +57,12 @@ supported_languages = {
     'Stylus': ['styl'],
     'Svelte': ['svelte'],
     'Swift': ['swift'],
+    'TOML': ['toml'],
     'TypeScript': ['ts', 'tsx'],
     'Vue': ['vue'],
     'Xtend': ['xtend'],
     'Xtext': ['xtext'],
+    'YAML': ['yaml', 'yml'],
 }
 
 _ext_lang = {}

--- a/test/test_detect_language.py
+++ b/test/test_detect_language.py
@@ -104,9 +104,12 @@ def test_languages_recognised():
     assert detect_language.detect_language("/tmp/some_file.styl") == "Stylus"
     assert detect_language.detect_language("/tmp/some_file.svelte") == "Svelte"
     assert detect_language.detect_language("/tmp/some_file.swift") == "Swift"
+    assert detect_language.detect_language("/tmp/some_file.toml") == "TOML"
     assert detect_language.detect_language("/tmp/some_file.ts") == "TypeScript"
     assert detect_language.detect_language(
         "/tmp/some_file.tsx") == "TypeScript"
     assert detect_language.detect_language("/tmp/some_file.vue") == "Vue"
     assert detect_language.detect_language("/tmp/some_file.xtend") == "Xtend"
     assert detect_language.detect_language("/tmp/some_file.xtext") == "Xtext"
+    assert detect_language.detect_language("/tmp/some_file.yaml") == "YAML"
+    assert detect_language.detect_language("/tmp/some_file.yml") == "YAML"


### PR DESCRIPTION
YAML and TOML are both supersets of JSON. JSON is already detected as language, so it would make sense to detect YAML and TOML as well.
I left ini out because it's not valid standardized markup.