### PR TITLE
Extract Perl libraries

### DIFF
--- a/src/language/Perl.py
+++ b/src/language/Perl.py
@@ -1,0 +1,31 @@
+import re
+
+def extract_libraries(files):
+    """Extracts a list of imports that were used in the files
+
+    Parameters
+    ----------
+    files : []string
+        Full paths to files that need to be analysed
+
+    Returns
+    -------
+    dict
+        imports that were used in the provided files, mapped against the language
+    """
+
+    res = []
+
+    # regex to find imports
+    regex = re.compile(r"(?:[^#]\s+)(?:use|require)[^\S\n]+(?:if.*,\s+)?[\"']?([a-zA-Z][a-zA-Z0-9:]*)[\"']?(?:\s+.*)?;")
+
+    for f in files:
+        with open(file=f, mode='r', errors='ignore') as fr:
+
+            contents = ' '.join(fr.readlines())
+            matches = regex.findall(contents)
+
+        if matches:
+            res.extend(matches)
+            print(res)
+    return {"Perl": res}

--- a/test/fixtures/Perl.pm
+++ b/test/fixtures/Perl.pm
@@ -1,0 +1,34 @@
+package Perl::Sample;
+
+# import with use
+use strict;
+use Benchmark;
+use Carp 'croak';
+use sigtrap qw(SEGV BUS);
+use Sub::Module;
+use Import::This 12.34;
+
+# conditional imports
+use if $] < 5.008, "utf8";
+use if WANT_WARNINGS, warnings => qw(all);
+
+# include with require
+require Foo::Bar;
+BEGIN { require Module; Module->import(LIST); }
+
+# versions
+use v5.32.0;
+use 5.30.3;
+use 5.028_003;
+
+require v5.26.3;
+require 5.24.4;
+require 5.022_004;
+
+# use Should::Not::Match;
+
+=pod
+
+Documentation lines about how to use this module should not match.
+
+=cut

--- a/test/test_Perl.py
+++ b/test/test_Perl.py
@@ -1,0 +1,22 @@
+import os
+from language.Perl import extract_libraries
+
+def test_extract_libraries():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    files = ['fixtures/Perl.pm']
+    fq_files = [os.path.join(dir_path, f) for f in files]
+    libs = extract_libraries(fq_files)
+    assert len(libs) == 1
+
+    assert libs['Perl'] == [
+        "strict",
+        "Benchmark",
+        "Carp",
+        "sigtrap",
+        "Sub::Module",
+        "Import::This",
+        "utf8",
+        "warnings",
+        "Foo::Bar",
+        "Module",
+    ]


### PR DESCRIPTION
This PR fixes #129 by adding sample fixtures and extractor tests for Perl, as well as an initial extractor based on regular expressions. I open it as a draft PR first for early feedback, and I'll mark it ready for review as soon as I consider it good enough for that.

Please review and merge, or let me know how to further improve it!