### PR TITLE
Recognize Perl test files by extension

### DIFF
--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -41,7 +41,7 @@ supported_languages = {
     'Nix': ['nix'],
     'Objective-C': ['mm'],
     'OpenEdge ABL': ['p', 'ab', 'w', 'i', 'x'],
-    'Perl': ['pl', 'pm'],
+    'Perl': ['pl', 'pm', 't'],
     'PHP': ['php'],
     'PLSQL': ['pks', 'pkb'],
     'Protocol Buffer': ['proto'],

--- a/test/test_detect_language.py
+++ b/test/test_detect_language.py
@@ -89,6 +89,7 @@ def test_languages_recognised():
     assert detect_language.detect_language("/tmp/some_file.pks") == "PLSQL"    
     assert detect_language.detect_language("/tmp/some_file.pl") == "Perl"
     assert detect_language.detect_language("/tmp/some_file.pm") == "Perl"
+    assert detect_language.detect_language("/tmp/some_file.t") == "Perl"
     assert detect_language.detect_language("/tmp/some_file.php") == "PHP"
     assert detect_language.detect_language(
         "/tmp/some_file.proto") == "Protocol Buffer"


### PR DESCRIPTION
Other than the different file extensions, Perl tests are normal Perl code, so it would be nice to include them in the Perl experince scoring.

Given the small size of the changeset, I hope you don't mind that I decided to directly open the PR without opening an issue first. Let me know if you would like to start with an issue instead.

This PR adds support to recognize Perl test files based on the file extension `.t`. 

Please review and merge, or let me know how to further improve it.