### PR TITLE
Detect ES6 module and CommonJS files

### DIFF
--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -30,7 +30,7 @@ supported_languages = {
     'HTML': ['html', 'htm', 'xhtml'],
     'JSON': ['json'],
     'Java': ['java'],
-    'JavaScript': ['js', 'jsx', 'mjs'],
+    'JavaScript': ['js', 'jsx', 'mjs', 'cjs'],
     'Jupyter Notebook': ['ipynb'],
     'Kivy': ['kv'],
     'Kotlin': ['kt', 'kts'],

--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -30,7 +30,7 @@ supported_languages = {
     'HTML': ['html', 'htm', 'xhtml'],
     'JSON': ['json'],
     'Java': ['java'],
-    'JavaScript': ['js', 'jsx'],
+    'JavaScript': ['js', 'jsx', 'mjs'],
     'Jupyter Notebook': ['ipynb'],
     'Kivy': ['kv'],
     'Kotlin': ['kt', 'kts'],

--- a/test/test_detect_language.py
+++ b/test/test_detect_language.py
@@ -66,6 +66,8 @@ def test_languages_recognised():
     assert detect_language.detect_language("/tmp/some_file.json") == "JSON"
     assert detect_language.detect_language("/tmp/some_file.java") == "Java"
     assert detect_language.detect_language("/tmp/some_file.js") == "JavaScript"
+    assert detect_language.detect_language("/tmp/some_file.mjs") == "JavaScript"
+    assert detect_language.detect_language("/tmp/some_file.cjs") == "JavaScript"
     assert detect_language.detect_language(
         "/tmp/some_file.jsx") == "JavaScript"
     assert detect_language.detect_language(


### PR DESCRIPTION
As described in the [NodeJS documentation](https://nodejs.org/api/esm.html#esm_enabling), `.mjs` and `.cjs` files are also valid JS.
ESM `import` library detection is already implemented.