### PR TITLE
New sh script to run repo_info_extractor in headless mode.

### DIFF
--- a/run-docker-headless.sh
+++ b/run-docker-headless.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+REPO_NAME=$(basename $1)
+docker run -i --mount type=bind,source="$1"/,target="/$REPO_NAME" --mount type=bind,source="$(pwd)"/,target="/app" codersrank/repo_info_extractor:latest ${@:2} /$REPO_NAME 

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 REPO_NAME=$(basename $1)
-docker run -it --mount type=bind,source="$1"/,target="/$REPO_NAME" --mount type=bind,source="$(pwd)"/,target="/app" codersrank/repo_info_extractor:latest /$REPO_NAME
+docker run -it --mount type=bind,source="$1"/,target="/$REPO_NAME" --mount type=bind,source="$(pwd)"/,target="/app" codersrank/repo_info_extractor:latest /$REPO_NAME 

--- a/run.sh
+++ b/run.sh
@@ -33,7 +33,6 @@ other_args=''
 
 trap "exitfn" INT
 
-
 local_projects() {
   number_of_repos=0
   concatenated_repos=()
@@ -63,10 +62,9 @@ local_projects() {
   #repostring=`printf "%s➕" "${concatenated_repos[@]}" | sed -e 's/➕$//g' `
   repostring=`printf "%s|,|" "${concatenated_repos[@]}" | sed -e 's/|,|$//g' `
 
-  python src/main.py $other_args "$repostring" ;\
+  python src/main.py "$repostring" $other_args ;\
   wait ;\
   return
- 
 }
 
 while getopts "$optspec" optchar; do

--- a/src/init.py
+++ b/src/init.py
@@ -147,6 +147,7 @@ def init_headless(directory, skip_obfuscation, output, parse_libraries, emails, 
             print("Email count (" + str(len(r.local_usernames)) + ") for this repo exceeds the limit of " + str(MAX_EMAIL_LIMIT) + " emails.")
             r.local_usernames = r.local_usernames[0:MAX_EMAIL_LIMIT]
         print('Setting the local user_names ::',r.local_usernames)
+        reponame = reponame.lstrip('/') # first char can't be / 
         r.repo_name = reponame
 
         if parse_libraries and len(ar.commit_list) > 0:

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,9 @@
 import argparse
-from init import initialize
+from init import initialize, init_headless
 from pprint import pprint
 import os
 from ui.questions import Questions
+from types import SimpleNamespace
 
 
 def main():
@@ -27,6 +28,7 @@ def main():
                         help='If the estimated size of the changed files is bigger than this, we skip the commit')
     parser.add_argument('--file_size_limit', default=2, type=int,
                         help='The library analyzer skips files bigger than this limit')
+    parser.add_argument('--headless', default=False, action='store_true', help="Run in headless mode.")    
     try:
         args = parser.parse_args()
         folders=args.directory.split('|,|')
@@ -43,9 +45,15 @@ def main():
                 print('Finished analyzing %s ' % (repo_name))
 
         else:
-            initialize(args.directory, args.skip_obfuscation, args.output,
-                       args.parse_libraries, args.email, args.skip_upload, args.debug_mode, args.skip,
-                       args.commit_size_limit, args.file_size_limit)
+            if args.headless:
+                seed = SimpleNamespace(emails=[args.email], user_name="", names=[])
+                init_headless(args.directory, args.skip_obfuscation, args.output,
+                        args.parse_libraries, [args.email], args.debug_mode, [], args.directory, args.skip,
+                        args.commit_size_limit, args.file_size_limit, seed)
+            else:
+                initialize(args.directory, args.skip_obfuscation, args.output,
+                        args.parse_libraries, args.email, args.skip_upload, args.debug_mode, args.skip,
+                        args.commit_size_limit, args.file_size_limit)
 
     except KeyboardInterrupt:
         print("Cancelled by user")


### PR DESCRIPTION
Fix reponame error in headless mode (because we don't have origin)
Modify run.sh & main.py to accept flags
And also allow script to be run in headless mode from command line.