### PR TITLE
Add languages for building compilers

### DIFF
--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -35,6 +35,7 @@ supported_languages = {
     'Kivy': ['kv'],
     'Kotlin': ['kt', 'kts'],
     'Less': ['less'], 
+    'Lex': ['l'],
     'Liquid': ['liquid'],
     'Lua': ['lua'],
     'MATLAB': ['m'],

--- a/src/language/detect_language.py
+++ b/src/language/detect_language.py
@@ -64,6 +64,7 @@ supported_languages = {
     'Vue': ['vue'],
     'Xtend': ['xtend'],
     'Xtext': ['xtext'],
+    'Yacc': ['y'],
 }
 
 _ext_lang = {}

--- a/test/test_detect_language.py
+++ b/test/test_detect_language.py
@@ -78,6 +78,7 @@ def test_languages_recognised():
     assert detect_language.detect_language("/tmp/some_file.kv") == "Kivy"
     assert detect_language.detect_language("/tmp/some_file.kt") == "Kotlin"
     assert detect_language.detect_language("/tmp/some_file.kts") == "Kotlin"
+    assert detect_language.detect_language("/tmp/some_file.l") == "Lex"
     assert detect_language.detect_language("/tmp/some_file.liquid") == "Liquid"
     assert detect_language.detect_language("/tmp/some_file.lua") == "Lua"
     assert detect_language.detect_language(pwd + "/test/fixtures/matlab.m") == "MATLAB"

--- a/test/test_detect_language.py
+++ b/test/test_detect_language.py
@@ -119,3 +119,4 @@ def test_languages_recognised():
     assert detect_language.detect_language("/tmp/some_file.vue") == "Vue"
     assert detect_language.detect_language("/tmp/some_file.xtend") == "Xtend"
     assert detect_language.detect_language("/tmp/some_file.xtext") == "Xtext"
+    assert detect_language.detect_language("/tmp/some_file.y") == "Yacc"


### PR DESCRIPTION
Lex/Yacc (and their successors Flex/Bison) are used to build lexers (by
convention defined in a .l file) and parsers (in a corresponding .y files).
Detect such languages used to build compilers.