### PR TITLE
fixed GetRepoName for repos with an explicit ssh:// prefix

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -164,7 +164,7 @@ func (r *RepoExtractor) GetRepoName(remoteOrigin string) string {
 	} else {
 		// Cloned using ssh
 		parts := strings.Split(remoteOrigin, ":")
-		repoName = parts[1]
+		repoName = parts[len(parts)-1]
 		parts = strings.Split(repoName, "/")
 		if r.Headless {
 			repoName = parts[len(parts)-2] + "/" + parts[len(parts)-1]


### PR DESCRIPTION
Hi @peti2001

According to our mail discussion - a quick fix suggestion:

For cases, when the origin url is like:

```
ssh://user@host:port/group/repoName.git
```

i.e. with an explicit "ssh://", `parts[1]` will catch a wrong part from:

```
[ssh //user@host port/group/repoName]
```
(the valid one index is [2])

At this moment this bug breaks repo uploads (from my local gogs) at https://codersrank.io/ (the repo name always shows as "user@host" and if I understood correctly, it cause a duplicate error when I try to "confirm" it using a token link.

Also there is a problem with repo scoring - they always show "0 exp.", but I think it is out of the current topic.

Thanks for your time!

Pavel.