### PR TITLE
Add Rust library detection support

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -165,6 +165,7 @@ func (r *RepoExtractor) initAnalyzers() {
 	librarydetection.AddAnalyzer("PHP", languages.NewPHPAnalyzer())
 	librarydetection.AddAnalyzer("Python", languages.NewPythonScriptAnalyzer())
 	librarydetection.AddAnalyzer("Ruby", languages.NewRubyScriptAnalyzer())
+	librarydetection.AddAnalyzer("Rust", languages.NewRustAnalyzer())
 	librarydetection.AddAnalyzer("Swift", languages.NewSwiftAnalyzer())
 }
 

--- a/librarydetection/languages/Rust.go
+++ b/librarydetection/languages/Rust.go
@@ -1,0 +1,30 @@
+package languages
+
+import (
+	"github.com/codersrank-org/repo_info_extractor/v2/librarydetection"
+	"regexp"
+)
+
+// NewRustAnalyzer constructor
+func NewRustAnalyzer() librarydetection.Analyzer {
+	return &rustAnalyzer{}
+}
+
+type rustAnalyzer struct {
+}
+
+func (a *rustAnalyzer) ExtractLibraries(contents string) ([]string, error) {
+	// regex to find "uses", braces are not supported as their tree syntax is too complicated for Go's regexes
+	useRegex, err := regexp.Compile(`use\s+(?:::)?(?:r#)?([^;:\s]+)`)
+	if err != nil {
+		return nil, err
+	}
+
+	// regex for "extern crate" statements
+	externCrateRegex, err := regexp.Compile(`extern\s+crate\s+(?:r#)?(\S+)\s*;`)
+	if err != nil {
+		return nil, err
+	}
+
+	return executeRegexes(contents, []*regexp.Regexp{useRegex, externCrateRegex}), nil
+}

--- a/librarydetection/languages/Rust_test.go
+++ b/librarydetection/languages/Rust_test.go
@@ -1,0 +1,36 @@
+package languages_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	"io/ioutil"
+
+	"github.com/codersrank-org/repo_info_extractor/v2/librarydetection/languages"
+)
+
+var _ = Describe("RustLibraryDetection", func() {
+	fixture, err := ioutil.ReadFile("./fixtures/rust.fixture")
+	if err != nil {
+		panic(err)
+	}
+
+	expectedLibraries := []string{
+		"lib1",
+		"lib2",
+		"lib3",
+		"lib4",
+		"lib5",
+		"lib6",
+	}
+
+	analyzer := languages.NewRustAnalyzer()
+
+	Describe("Extract Rust Libraries", func() {
+		It("Should be able to extract libraries", func() {
+			libs, err := analyzer.ExtractLibraries(string(fixture))
+			if err != nil {
+				panic(err)
+			}
+			assertSameUnordered(libs, expectedLibraries)
+		})
+	})
+})

--- a/librarydetection/languages/fixtures/rust.fixture
+++ b/librarydetection/languages/fixtures/rust.fixture
@@ -1,0 +1,11 @@
+extern crate lib1;
+#[macro_use]
+extern crate lib2;
+
+use lib3::io::test;
+use lib4 as something;
+// whitespace action
+use
+	  lib5::test as hi;
+// global path with a raw name
+use ::r#lib6;


### PR DESCRIPTION
This implements library detection support for Rust as per request in codersrank-org/libraries#121 :)

The support is implemented based on the following Rust statements:
 - `extern crate <something>` especially for crates contributing macros
 - `use <something>` for everything else

## Caveats

### Scope of the `use` detection

The detection uses a simple regex to check for the most common types of usage declarations.
I think this should cover almost all variants found in the wild, including the root syntax (`::<something>`) and the raw syntax (`r#<something>`).

This does not cover some more complex use trees that are allowed by the language specification, but practically not used:
`use {{{lib1, lib2}, lib3}}` is a legal import (see the grammar [here][reference-use]) but is not supported by this implementation.

I'd say that use trees on the top level are not used in practice and are just flattened into multiple use statements, in this case:
```
use lib1;
use lib2;
use lib3;
```

### Using a library without `use`

Citing from the [Rust reference][reference-use]:
> A use declaration creates one or more local name bindings synonymous with some other [path](https://doc.rust-lang.org/stable/reference/paths.html). Usually a use declaration is used to shorten the path required to refer to a module item. These declarations may appear in [modules](https://doc.rust-lang.org/stable/reference/items/modules.html) and [blocks](https://doc.rust-lang.org/stable/reference/expressions/block-expr.html), usually at the top.

There is no requirement to `use` a library as you can always just type out the complete path.

In my opinion it is reasonable to assume though, that at some point in the code there will be some `use`s when working with larger libraries.

## Alternatives

1. Scan the code for usages of the library ids in paths like `<library>::<rest of the path>`.
   This is prone to be faulty though as it is pretty likely that the ids of some popular libraries such as `log` or `chrono` are also used as local modules.
2. Just read in the `Cargo.toml` file.
   On the pro side:
     - `cargo` is basically the standard or project definitions in Rust
     - the project manifests give the ultimate insight into which libraries are used to build the project
   On the con side:
     - no other library analyzer in this project relies on project manifests
     - manifests are no indication of actual usage of a library

[reference-use]: https://doc.rust-lang.org/stable/reference/items/use-declarations.html

---

I'd like to hear your opinions about the caveats and alternatives.