### PR TITLE
Recognize pod files as Perl

### DIFF
--- a/languagedetection/analyzer.go
+++ b/languagedetection/analyzer.go
@@ -158,7 +158,7 @@ var fileExtensionMap = map[string][]string{
 	"Nix":              {"nix"},
 	"Objective-C":      {"mm"},
 	"OpenEdge ABL":     {"p", "ab", "w", "i", "x"},
-	"Perl":             {"pl", "pm", "t"},
+	"Perl":             {"pl", "pm", "pod", "t"},
 	"PHP":              {"php"},
 	"PLSQL":            {"pks", "pkb"},
 	"Protocol Buffer":  {"proto"},


### PR DESCRIPTION
[The Plain Old Documentation format](https://perldoc.perl.org/perlpod) can be embedded in the same file where the code lives, but sometimes it is in a separate file with `pod` extension.

Similarly to how `pod6` files are currently recognized as Raku, I propose recognizing `pod` files as Perl.